### PR TITLE
[Feat] Swagger 및 Spring Security 설정 추가

### DIFF
--- a/src/main/java/com/shcho/shBlog/common/config/SecurityConfig.java
+++ b/src/main/java/com/shcho/shBlog/common/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.shcho.shBlog.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        // Swagger 관련 경로 허용
+                        .requestMatchers(
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html"
+                        ).permitAll()
+                        // 그 외 경로는 인증 필요
+                        .anyRequest().authenticated()
+                )
+                .httpBasic(Customizer.withDefaults());
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/shcho/shBlog/common/config/SwaggerConfig.java
+++ b/src/main/java/com/shcho/shBlog/common/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+
+package com.shcho.shBlog.common.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "ShBlog API",
+                version = "v1",
+                description = "개인 블로그 프로젝트 백엔드 API 명세"
+        ),
+        security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth",
+                                new io.swagger.v3.oas.models.security.SecurityScheme()
+                                        .type(io.swagger.v3.oas.models.security.SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                                        .in(io.swagger.v3.oas.models.security.SecurityScheme.In.HEADER)
+                                        .name("Authorization")
+                        ))
+                .addSecurityItem(new io.swagger.v3.oas.models.security.SecurityRequirement().addList("bearerAuth"));
+    }
+}


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] Swagger 및 Spring Security 설정 추가

## ✅ 작업 내용
- Swagger(OpenAPI) 설정 파일 `SwaggerConfig` 추가  
  - API 명세 기본 정보(title, version, description) 설정  
  - JWT 인증용 `bearerAuth` 보안 스키마 등록  
  - 모든 API 요청에 Security Requirement(`bearerAuth`) 적용  
- Spring Security 설정 파일 `SecurityConfig` 추가  
  - Swagger 관련 경로(`/v3/api-docs/**`, `/swagger-ui/**`, `/swagger-ui.html`)는 permitAll  
  - 나머지 모든 요청은 인증 필요하도록 설정  
  - CSRF 비활성화 및 기본 HTTP 보안 설정 구성  

## 🔧 변경사항
<!-- 어떤 파일이 추가/수정/삭제되었는지 -->
- `common/config/SecurityConfig.java` 추가  
- `common/config/SwaggerConfig.java` 추가  

## 📌 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요 -->
- close #3 