### PR TITLE
[Feat] User Entity 및 Repository 설계

### DIFF
--- a/src/main/java/com/shcho/shBlog/ShBlogApplication.java
+++ b/src/main/java/com/shcho/shBlog/ShBlogApplication.java
@@ -2,8 +2,10 @@ package com.shcho.shBlog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ShBlogApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/shcho/shBlog/common/entity/BaseEntity.java
+++ b/src/main/java/com/shcho/shBlog/common/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.shcho.shBlog.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
 
     /* 404 NOT_FOUND */
     USER_NOT_FOUND(404, "USER_001", "유저를 찾을 수 없습니다."),
+    ALREADY_DELETED_USER(404, "USER_002", "이미 삭제된 유저입니다."),
 
     /* 401 UNAUTHORIZED */
 

--- a/src/main/java/com/shcho/shBlog/user/entity/Role.java
+++ b/src/main/java/com/shcho/shBlog/user/entity/Role.java
@@ -1,0 +1,5 @@
+package com.shcho.shBlog.user.entity;
+
+public enum Role {
+    ADMIN, USER
+}

--- a/src/main/java/com/shcho/shBlog/user/entity/User.java
+++ b/src/main/java/com/shcho/shBlog/user/entity/User.java
@@ -1,0 +1,95 @@
+package com.shcho.shBlog.user.entity;
+
+import com.shcho.shBlog.common.entity.BaseEntity;
+import com.shcho.shBlog.libs.exception.CustomException;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static com.shcho.shBlog.libs.exception.ErrorCode.ALREADY_DELETED_USER;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @Column
+    private String password;
+
+    @Column
+    private String nickname;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column
+    private String profileImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "VARCHAR(50)")
+    private Role role;
+
+    @Column
+    private LocalDateTime deletedAt;
+
+    public static User of(String username, String encodedPassword, String nickname, String email) {
+        return User.builder()
+                .username(username)
+                .password(encodedPassword)
+                .nickname(nickname)
+                .email(email)
+                .role(Role.USER)
+                .build();
+    }
+
+    public void updateUsername(String username) {
+        this.username = username;
+    }
+
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void deleteProfileImageUrl() {
+        this.profileImageUrl = null;
+    }
+
+    public void withdraw() {
+        if (this.deletedAt != null) {
+            throw new CustomException(ALREADY_DELETED_USER);
+        }
+        this.deletedAt = LocalDateTime.now();
+        this.username = "DELETED_" + this.username;
+        this.password = null;
+        this.nickname = null;
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+}

--- a/src/main/java/com/shcho/shBlog/user/repository/UserRepository.java
+++ b/src/main/java/com/shcho/shBlog/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.shcho.shBlog.user.repository;
+
+import com.shcho.shBlog.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] User 엔티티 및 Repository 구현

## ✅ 작업 내용
- 개인 블로그 플랫폼용 User 엔티티 생성
- 기본 필드(username, password, nickname, email, profileImageUrl, role, deletedAt) 설계
- BaseEntity 상속 및 JPA Auditing 적용
- withdraw() 메서드를 통한 soft delete 로직 구현
- UserRepository 인터페이스 생성

## 🔧 변경사항
- User.java 생성 (com.shcho.shBlog.user.entity)
- UserRepository.java 생성 (com.shcho.shBlog.user.repository)
- Role.java 생성 (USER, ADMIN 포함)
- ErrorCode.java에 사용자 관련 에러 추가 (USER_NOT_FOUND, ALREADY_DELETED_USER)

## 📌 관련 이슈
- close #6 