### PR TITLE
[Feat] BlogPage 엔티티 및 레포지토리 생성

### DIFF
--- a/src/main/java/com/shcho/shBlog/blogpage/entity/BlogPage.java
+++ b/src/main/java/com/shcho/shBlog/blogpage/entity/BlogPage.java
@@ -1,0 +1,40 @@
+package com.shcho.shBlog.blogpage.entity;
+
+import com.shcho.shBlog.common.entity.BaseEntity;
+import com.shcho.shBlog.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BlogPage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String intro;
+
+    private String bannerImageUrl;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public static BlogPage createDefault(User user){
+        return BlogPage.builder()
+                .title(user.getNickname() + "의 블로그")
+                .intro("")
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/shcho/shBlog/blogpage/repository/BlogPageRepository.java
+++ b/src/main/java/com/shcho/shBlog/blogpage/repository/BlogPageRepository.java
@@ -1,0 +1,7 @@
+package com.shcho.shBlog.blogpage.repository;
+
+import com.shcho.shBlog.blogpage.entity.BlogPage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlogPageRepository extends JpaRepository<BlogPage, Long> {
+}

--- a/src/main/java/com/shcho/shBlog/user/entity/User.java
+++ b/src/main/java/com/shcho/shBlog/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.shcho.shBlog.user.entity;
 
+import com.shcho.shBlog.blogpage.entity.BlogPage;
 import com.shcho.shBlog.common.entity.BaseEntity;
 import com.shcho.shBlog.libs.exception.CustomException;
 import jakarta.persistence.*;
@@ -42,6 +43,9 @@ public class User extends BaseEntity {
     @Column(nullable = false, columnDefinition = "VARCHAR(50)")
     private Role role;
 
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+    private BlogPage blogPage;
+
     @Column
     private LocalDateTime deletedAt;
 
@@ -53,6 +57,10 @@ public class User extends BaseEntity {
                 .email(email)
                 .role(Role.USER)
                 .build();
+    }
+
+    public void setBlogPage(BlogPage blogPage) {
+        this.blogPage = blogPage;
     }
 
     public void updateUsername(String username) {


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] BlogPage 엔티티 및 레포지토리 생성

## ✅ 작업 내용
- BlogPage 엔티티 생성
    - 필드: id, title, intro, bannerImageUrl
    - BaseEntity 상속으로 createdAt, updatedAt 자동 관리
    - User와 1:1 연관관계 설정 (@OneToOne(fetch = LAZY) + @JoinColumn)
    - 기본 블로그 페이지 생성 메서드 createDefault(User) 구현
- User 엔티티 수정
    - @OneToOne(mappedBy = "user", cascade = ALL) 매핑 추가
    - setBlogPage() 메서드 추가
- BlogPageRepository 생성

## 🔧 변경사항
- BlogPage.java (신규)
- BlogPageRepository.java (신규)
- User.java (BlogPage 연관관계 필드 및 setter 추가)

## 📌 관련 이슈
- close #13 