### PR TITLE
[Feat] BlogPage 조회 API 구현

### DIFF
--- a/src/main/java/com/shcho/shBlog/blogpage/controller/BlogPageController.java
+++ b/src/main/java/com/shcho/shBlog/blogpage/controller/BlogPageController.java
@@ -1,0 +1,40 @@
+package com.shcho.shBlog.blogpage.controller;
+
+import com.shcho.shBlog.blogpage.dto.BlogPageResponseDto;
+import com.shcho.shBlog.blogpage.entity.BlogPage;
+import com.shcho.shBlog.blogpage.service.BlogPageService;
+import com.shcho.shBlog.user.auth.CustomUserDetails;
+import com.shcho.shBlog.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/blog/page")
+@RequiredArgsConstructor
+public class BlogPageController {
+
+    private final BlogPageService blogPageService;
+
+    @GetMapping("/me")
+    public ResponseEntity<BlogPageResponseDto> getBlogPage(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        BlogPage blogPage = blogPageService.getBlogPageById(userDetails.getUserId());
+
+        return ResponseEntity.ok(BlogPageResponseDto.from(blogPage));
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<BlogPageResponseDto> getBlogPageByUserId(
+            @PathVariable Long userId
+    ) {
+        BlogPage blogPage = blogPageService.getBlogPageById(userId);
+
+        return ResponseEntity.ok(BlogPageResponseDto.from(blogPage));
+    }
+}

--- a/src/main/java/com/shcho/shBlog/blogpage/controller/BlogPageController.java
+++ b/src/main/java/com/shcho/shBlog/blogpage/controller/BlogPageController.java
@@ -4,7 +4,6 @@ import com.shcho.shBlog.blogpage.dto.BlogPageResponseDto;
 import com.shcho.shBlog.blogpage.entity.BlogPage;
 import com.shcho.shBlog.blogpage.service.BlogPageService;
 import com.shcho.shBlog.user.auth.CustomUserDetails;
-import com.shcho.shBlog.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/com/shcho/shBlog/blogpage/dto/BlogPageResponseDto.java
+++ b/src/main/java/com/shcho/shBlog/blogpage/dto/BlogPageResponseDto.java
@@ -1,16 +1,15 @@
 package com.shcho.shBlog.blogpage.dto;
 
 import com.shcho.shBlog.blogpage.entity.BlogPage;
-import com.shcho.shBlog.user.entity.User;
 
-public record BlogPageResponseDto (
+public record BlogPageResponseDto(
         Long id,
         String title,
         String intro,
         String bannerImageUrl,
         String userNickName,
         String userProfileImageUrl
-){
+) {
     public static BlogPageResponseDto from(BlogPage blogPage) {
         return new BlogPageResponseDto(
                 blogPage.getId(),

--- a/src/main/java/com/shcho/shBlog/blogpage/dto/BlogPageResponseDto.java
+++ b/src/main/java/com/shcho/shBlog/blogpage/dto/BlogPageResponseDto.java
@@ -1,0 +1,24 @@
+package com.shcho.shBlog.blogpage.dto;
+
+import com.shcho.shBlog.blogpage.entity.BlogPage;
+import com.shcho.shBlog.user.entity.User;
+
+public record BlogPageResponseDto (
+        Long id,
+        String title,
+        String intro,
+        String bannerImageUrl,
+        String userNickName,
+        String userProfileImageUrl
+){
+    public static BlogPageResponseDto from(BlogPage blogPage) {
+        return new BlogPageResponseDto(
+                blogPage.getId(),
+                blogPage.getTitle(),
+                blogPage.getIntro(),
+                blogPage.getBannerImageUrl(),
+                blogPage.getUser().getNickname(),
+                blogPage.getUser().getProfileImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/shcho/shBlog/blogpage/repository/BlogPageRepository.java
+++ b/src/main/java/com/shcho/shBlog/blogpage/repository/BlogPageRepository.java
@@ -3,5 +3,8 @@ package com.shcho.shBlog.blogpage.repository;
 import com.shcho.shBlog.blogpage.entity.BlogPage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BlogPageRepository extends JpaRepository<BlogPage, Long> {
+    Optional<BlogPage> getBlogPageByUser_UserId(Long userUserId);
 }

--- a/src/main/java/com/shcho/shBlog/blogpage/service/BlogPageService.java
+++ b/src/main/java/com/shcho/shBlog/blogpage/service/BlogPageService.java
@@ -1,0 +1,22 @@
+package com.shcho.shBlog.blogpage.service;
+
+import com.shcho.shBlog.blogpage.entity.BlogPage;
+import com.shcho.shBlog.blogpage.repository.BlogPageRepository;
+import com.shcho.shBlog.libs.exception.CustomException;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.shcho.shBlog.libs.exception.ErrorCode.BLOG_PAGE_NOT_FOUND;
+
+@Service
+@AllArgsConstructor
+public class BlogPageService {
+
+    private final BlogPageRepository blogPageRepository;
+
+    public BlogPage getBlogPageById(Long userId) {
+        return blogPageRepository.getBlogPageByUser_UserId(userId)
+                .orElseThrow(() -> new CustomException(BLOG_PAGE_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/shcho/shBlog/common/config/SecurityConfig.java
+++ b/src/main/java/com/shcho/shBlog/common/config/SecurityConfig.java
@@ -40,6 +40,9 @@ public class SecurityConfig {
                                 "/swagger-ui.html"
                         ).permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/blog/page/me").authenticated()
+                        .requestMatchers("/api/blog/page/**").permitAll()
+
                         // 그 외 경로는 인증 필요
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     /* 404 NOT_FOUND */
     USER_NOT_FOUND(404, "USER_001", "유저를 찾을 수 없습니다."),
     ALREADY_DELETED_USER(404, "USER_002", "이미 삭제된 유저입니다."),
+    BLOG_PAGE_NOT_FOUND(404, "BLOG_PAGE_001", "해당 블로그 페이지를 찾을 수 없습니다."),
 
     /* 401 UNAUTHORIZED */
     INVALID_USERNAME_OR_PASSWORD(401, "AUTH_001", "아이디 또는 비밀번호가 올바르지 않습니다."),

--- a/src/main/java/com/shcho/shBlog/user/auth/CustomUserDetails.java
+++ b/src/main/java/com/shcho/shBlog/user/auth/CustomUserDetails.java
@@ -9,6 +9,9 @@ import java.util.Collections;
 
 public record CustomUserDetails(User user) implements UserDetails {
 
+    public Long getUserId() {
+        return user.getUserId();
+    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/test/java/com/shcho/shBlog/blogpage/service/BlogPageServiceTest.java
+++ b/src/test/java/com/shcho/shBlog/blogpage/service/BlogPageServiceTest.java
@@ -1,0 +1,83 @@
+package com.shcho.shBlog.blogpage.service;
+
+import com.shcho.shBlog.blogpage.entity.BlogPage;
+import com.shcho.shBlog.blogpage.repository.BlogPageRepository;
+import com.shcho.shBlog.libs.exception.CustomException;
+import com.shcho.shBlog.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static com.shcho.shBlog.libs.exception.ErrorCode.BLOG_PAGE_NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("Blog Page Service Unit Test")
+class BlogPageServiceTest {
+
+    @Mock
+    private BlogPageRepository blogPageRepository;
+
+    @InjectMocks
+    private BlogPageService blogPageService;
+
+    public BlogPageServiceTest() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("Blog Page 조회 성공")
+    void getBlogPageSuccess() {
+        // given
+        User user = User.builder()
+                .userId(1L)
+                .nickname("nickname")
+                .build();
+
+        BlogPage blogPage = BlogPage.builder()
+                .id(1L)
+                .title("nickname의 블로그")
+                .intro("")
+                .bannerImageUrl(null)
+                .user(user)
+                .build();
+
+        when(blogPageRepository.getBlogPageByUser_UserId(user.getUserId()))
+                .thenReturn(Optional.of(blogPage));
+
+        // when
+        BlogPage foundBlogPage = blogPageService.getBlogPageById(user.getUserId());
+
+        // then
+        assertNotNull(foundBlogPage);
+        assertEquals(1L, foundBlogPage.getId());
+        assertEquals("nickname의 블로그", foundBlogPage.getTitle());
+        assertEquals(user, foundBlogPage.getUser());
+        verify(blogPageRepository, times(1))
+                .getBlogPageByUser_UserId(user.getUserId());
+    }
+
+    @Test
+    @DisplayName("Blog Page 조회 실패 - BLOG_PAGE_NOT_FOUND")
+    void getBlogPageFailureBlogPageNotFound() {
+        // given
+        Long userId = 999L;
+
+        when(blogPageRepository.getBlogPageByUser_UserId(userId))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> blogPageService.getBlogPageById(userId));
+
+        assertEquals(BLOG_PAGE_NOT_FOUND, exception.getErrorCode());
+        verify(blogPageRepository, times(1))
+                .getBlogPageByUser_UserId(999L);
+
+    }
+
+}


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] BlogPage 조회 API 구현

## ✅ 작업 내용
- BlogPageResponseDto 생성 및 from() 변환 메서드 추가
- BlogPageRepository에 Optional 기반 조회 메서드 추가
- BlogPageService.getBlogPageById() 구현
  - BlogPage 미존재 시 BLOG_PAGE_NOT_FOUND 예외 처리
- BlogPageController 구현
  - GET `/api/blog/page/me` — 로그인된 사용자 블로그 조회
  - GET `/api/blog/page/{userId}` — 특정 사용자 블로그 조회
- SecurityConfig에 블로그 조회 API 인증/허용 정책 추가

## 🔧 변경사항
- `BlogPageResponseDto.java` 생성
- `BlogPageRepository.java` 수정
- `BlogPageService.java` 수정
- `BlogPageController.java` 생성
- `SecurityConfig.java` 수정
- `ErrorCode.java` 수정 (BLOG_PAGE_NOT_FOUND 추가)

## 📌 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요 -->
- close #15