### PR TITLE
[Feat] BlogPage 수정 API 구현

### DIFF
--- a/src/main/java/com/shcho/shBlog/blogpage/controller/BlogPageController.java
+++ b/src/main/java/com/shcho/shBlog/blogpage/controller/BlogPageController.java
@@ -1,16 +1,15 @@
 package com.shcho.shBlog.blogpage.controller;
 
 import com.shcho.shBlog.blogpage.dto.BlogPageResponseDto;
+import com.shcho.shBlog.blogpage.dto.BlogPageUpdateRequestDto;
 import com.shcho.shBlog.blogpage.entity.BlogPage;
 import com.shcho.shBlog.blogpage.service.BlogPageService;
 import com.shcho.shBlog.user.auth.CustomUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/blog/page")
@@ -35,5 +34,17 @@ public class BlogPageController {
         BlogPage blogPage = blogPageService.getBlogPageById(userId);
 
         return ResponseEntity.ok(BlogPageResponseDto.from(blogPage));
+    }
+
+    @PutMapping("/me")
+    public ResponseEntity<BlogPageResponseDto> updateBlogPage(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody BlogPageUpdateRequestDto requestDto
+    ){
+        BlogPage updatedBlogPage = blogPageService.updateMyBlogPage(
+                        userDetails.getUserId(), requestDto
+                );
+
+        return ResponseEntity.ok(BlogPageResponseDto.from(updatedBlogPage));
     }
 }

--- a/src/main/java/com/shcho/shBlog/blogpage/dto/BlogPageUpdateRequestDto.java
+++ b/src/main/java/com/shcho/shBlog/blogpage/dto/BlogPageUpdateRequestDto.java
@@ -1,0 +1,10 @@
+package com.shcho.shBlog.blogpage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record BlogPageUpdateRequestDto(
+        @NotBlank String title,
+        String intro,
+        String bannerImageUrl
+) {
+}

--- a/src/main/java/com/shcho/shBlog/blogpage/entity/BlogPage.java
+++ b/src/main/java/com/shcho/shBlog/blogpage/entity/BlogPage.java
@@ -38,4 +38,16 @@ public class BlogPage extends BaseEntity {
                 .user(user)
                 .build();
     }
+
+    public void setTitle(String title){
+        this.title = title;
+    }
+
+    public void setIntro(String intro){
+        this.intro = intro;
+    }
+
+    public void setBannerImageUrl(String bannerImageUrl){
+        this.bannerImageUrl = bannerImageUrl;
+    }
 }

--- a/src/main/java/com/shcho/shBlog/blogpage/service/BlogPageService.java
+++ b/src/main/java/com/shcho/shBlog/blogpage/service/BlogPageService.java
@@ -1,5 +1,6 @@
 package com.shcho.shBlog.blogpage.service;
 
+import com.shcho.shBlog.blogpage.dto.BlogPageUpdateRequestDto;
 import com.shcho.shBlog.blogpage.entity.BlogPage;
 import com.shcho.shBlog.blogpage.repository.BlogPageRepository;
 import com.shcho.shBlog.libs.exception.CustomException;
@@ -7,6 +8,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import static com.shcho.shBlog.libs.exception.ErrorCode.BLOG_PAGE_NOT_FOUND;
+import static com.shcho.shBlog.libs.exception.ErrorCode.NO_PERMISSION;
 
 @Service
 @AllArgsConstructor
@@ -17,6 +19,20 @@ public class BlogPageService {
     public BlogPage getBlogPageById(Long userId) {
         return blogPageRepository.getBlogPageByUser_UserId(userId)
                 .orElseThrow(() -> new CustomException(BLOG_PAGE_NOT_FOUND));
+    }
+
+    public BlogPage updateMyBlogPage(Long userId, BlogPageUpdateRequestDto updateRequestDto) {
+        BlogPage blogPage = getBlogPageById(userId);
+
+        if (!blogPage.getUser().getUserId().equals(userId)) {
+            throw new CustomException(NO_PERMISSION);
+        }
+
+        blogPage.setTitle(updateRequestDto.title());
+        blogPage.setIntro(updateRequestDto.intro());
+        blogPage.setBannerImageUrl(updateRequestDto.bannerImageUrl());
+
+        return blogPageRepository.save(blogPage);
     }
 
 }

--- a/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     INVALID_USERNAME_OR_PASSWORD(401, "AUTH_001", "아이디 또는 비밀번호가 올바르지 않습니다."),
 
     /* 403 FORBIDDEN */
+    NO_PERMISSION(403, "COMMON_403", "해당 작업을 할 권한이 없습니다."),
 
     /* 409 CONFLICT */
     DUPLICATED_USERNAME(409, "USER_003", "이미 사용중인 아이디 입니다."),

--- a/src/test/java/com/shcho/shBlog/blogpage/service/BlogPageServiceTest.java
+++ b/src/test/java/com/shcho/shBlog/blogpage/service/BlogPageServiceTest.java
@@ -1,5 +1,6 @@
 package com.shcho.shBlog.blogpage.service;
 
+import com.shcho.shBlog.blogpage.dto.BlogPageUpdateRequestDto;
 import com.shcho.shBlog.blogpage.entity.BlogPage;
 import com.shcho.shBlog.blogpage.repository.BlogPageRepository;
 import com.shcho.shBlog.libs.exception.CustomException;
@@ -13,6 +14,7 @@ import org.mockito.MockitoAnnotations;
 import java.util.Optional;
 
 import static com.shcho.shBlog.libs.exception.ErrorCode.BLOG_PAGE_NOT_FOUND;
+import static com.shcho.shBlog.libs.exception.ErrorCode.NO_PERMISSION;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -80,4 +82,106 @@ class BlogPageServiceTest {
 
     }
 
+    @Test
+    @DisplayName("Blog Page 수정 성공")
+    void updateBlogPageSuccess() {
+        // given
+        Long userId = 1L;
+
+        User user = User.builder()
+                .userId(1L)
+                .nickname("nickname")
+                .build();
+
+        BlogPage blogPage = BlogPage.builder()
+                .id(1L)
+                .title("oldTitle")
+                .intro("oldIntro")
+                .bannerImageUrl(null)
+                .user(user)
+                .build();
+
+        BlogPageUpdateRequestDto requestDto = new BlogPageUpdateRequestDto(
+                "newTitle",
+                "newIntro",
+                "newBanner"
+        );
+
+        when(blogPageRepository.getBlogPageByUser_UserId(userId))
+                .thenReturn(Optional.of(blogPage));
+
+        when(blogPageRepository.save(blogPage))
+                .thenReturn(blogPage);
+
+        // when
+        BlogPage updatedBlogPage = blogPageService.updateMyBlogPage(
+                userId, requestDto
+        );
+
+        // then
+        assertEquals("newTitle", updatedBlogPage.getTitle());
+        assertEquals("newIntro", updatedBlogPage.getIntro());
+        assertEquals("newBanner", updatedBlogPage.getBannerImageUrl());
+
+        verify(blogPageRepository, times(1)).save(blogPage);
+    }
+
+    @Test
+    @DisplayName("Blog Page 수정 실패 - BLOG_PAGE_NOT_FOUND")
+    void updateBlogPageFailureBlogPageNotFound() {
+        // given
+        Long userId = 999L;
+
+        BlogPageUpdateRequestDto requestDto = new BlogPageUpdateRequestDto(
+                "title",
+                "intro",
+                "banner"
+        );
+
+        when(blogPageRepository.getBlogPageByUser_UserId(userId))
+                .thenReturn(Optional.empty());
+
+        // when && then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> blogPageService.updateMyBlogPage(userId, requestDto)
+        );
+
+        assertEquals(BLOG_PAGE_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("Blog Page 수정 실패 - 본인 블로그가 아님 - NO_PERMISSION")
+    void updateBlogPageFailureNotOwner() {
+        // given
+        Long editorUserId = 1L;
+        Long ownerUserId = 2L;
+
+        User owner = User.builder()
+                .userId(ownerUserId)
+                .nickname("owner")
+                .build();
+
+        BlogPage blogPage = BlogPage.builder()
+                .id(1L)
+                .title("oldTitle")
+                .intro("oldIntro")
+                .bannerImageUrl(null)
+                .user(owner)
+                .build();
+
+        BlogPageUpdateRequestDto requestDto = new BlogPageUpdateRequestDto(
+                "newTitle",
+                "newIntro",
+                "newBanner"
+        );
+
+        when(blogPageRepository.getBlogPageByUser_UserId(editorUserId))
+                .thenReturn(Optional.of(blogPage));
+
+        // when && then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> blogPageService.updateMyBlogPage(editorUserId, requestDto));
+
+        assertEquals(NO_PERMISSION, exception.getErrorCode());
+    }
 }


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] BlogPage 수정 API 구현

## ✅ 작업 내용
- BlogPageUpdateRequestDto 생성
- BlogPageService.updateMyBlogPage() 구현
  - BlogPage 조회 및 예외 처리
  - 본인 소유 여부 검증 (NO_PERMISSION)
  - title / intro / bannerImageUrl 업데이트
- PUT `/api/blog/page/me` 컨트롤러 추가
- validation 적용 (@Valid @RequestBody)

## 🔧 변경사항
- BlogPage 엔티티 setter 추가
- BlogPageController 수정 API 추가
- BlogPageService 로직 확장
- ErrorCode 활용 (NO_PERMISSION)

## 🧪 단위 테스트
- BlogPage 수정 성공 테스트
- BlogPage 없음 → BLOG_PAGE_NOT_FOUND 테스트
- 본인 BlogPage 아님 → NO_PERMISSION 테스트

## 📌 관련 이슈
- close #16
- close #12 