### PR TITLE
[Feat] Category 도메인 구현 및 서비스/테스트 추가

### DIFF
--- a/src/main/java/com/shcho/shBlog/category/controller/CategoryController.java
+++ b/src/main/java/com/shcho/shBlog/category/controller/CategoryController.java
@@ -3,10 +3,10 @@ package com.shcho.shBlog.category.controller;
 import com.shcho.shBlog.category.dto.CategoryResponseDto;
 import com.shcho.shBlog.category.dto.CreateCategoryRequestDto;
 import com.shcho.shBlog.category.dto.CreateCategoryResponseDto;
+import com.shcho.shBlog.category.dto.UpdateCategoryRequestDto;
 import com.shcho.shBlog.category.entity.Category;
 import com.shcho.shBlog.category.service.CategoryService;
 import com.shcho.shBlog.user.auth.CustomUserDetails;
-import com.shcho.shBlog.user.entity.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -49,7 +49,7 @@ public class CategoryController {
     public ResponseEntity<CategoryResponseDto> updateCategory(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long categoryId,
-            @Valid @RequestBody CreateCategoryRequestDto requestDto
+            @Valid @RequestBody UpdateCategoryRequestDto requestDto
     ) {
         Long userId = userDetails.getUserId();
         Category updatedCategory =

--- a/src/main/java/com/shcho/shBlog/category/controller/CategoryController.java
+++ b/src/main/java/com/shcho/shBlog/category/controller/CategoryController.java
@@ -1,0 +1,71 @@
+package com.shcho.shBlog.category.controller;
+
+import com.shcho.shBlog.category.dto.CategoryResponseDto;
+import com.shcho.shBlog.category.dto.CreateCategoryRequestDto;
+import com.shcho.shBlog.category.dto.CreateCategoryResponseDto;
+import com.shcho.shBlog.category.entity.Category;
+import com.shcho.shBlog.category.service.CategoryService;
+import com.shcho.shBlog.user.auth.CustomUserDetails;
+import com.shcho.shBlog.user.entity.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/category")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @PostMapping
+    public ResponseEntity<CreateCategoryResponseDto> createCategory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody CreateCategoryRequestDto requestDto
+    ) {
+        Long userId = userDetails.getUserId();
+        Category newCategory = categoryService.createCategory(userId, requestDto);
+
+        return ResponseEntity.ok(CreateCategoryResponseDto.from(newCategory));
+    }
+
+    @GetMapping("/{blogPageId}")
+    public ResponseEntity<List<CategoryResponseDto>> getAllCategoriesByBlogPage(
+            @PathVariable Long blogPageId
+    ) {
+        List<CategoryResponseDto> categories = categoryService.getAllCategoriesByBlogPageId(blogPageId)
+                .stream()
+                .map(CategoryResponseDto::from)
+                .toList();
+
+        return ResponseEntity.ok(categories);
+    }
+
+    @PutMapping("/{categoryId}")
+    public ResponseEntity<CategoryResponseDto> updateCategory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long categoryId,
+            @Valid @RequestBody CreateCategoryRequestDto requestDto
+    ) {
+        Long userId = userDetails.getUserId();
+        Category updatedCategory =
+                categoryService.updateCategory(userId, categoryId, requestDto);
+
+        return ResponseEntity.ok(CategoryResponseDto.from(updatedCategory));
+    }
+
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<Void> deleteCategory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long categoryId
+    ) {
+        Long userId = userDetails.getUserId();
+        categoryService.deleteCategoryByCategoryId(userId, categoryId);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/shcho/shBlog/category/dto/CategoryResponseDto.java
+++ b/src/main/java/com/shcho/shBlog/category/dto/CategoryResponseDto.java
@@ -1,0 +1,17 @@
+package com.shcho.shBlog.category.dto;
+
+import com.shcho.shBlog.category.entity.Category;
+
+public record CategoryResponseDto(
+        Long id,
+        String name,
+        String description
+) {
+    public static CategoryResponseDto from(Category category) {
+        return new CategoryResponseDto(
+                category.getId(),
+                category.getName(),
+                category.getDescription()
+        );
+    }
+}

--- a/src/main/java/com/shcho/shBlog/category/dto/CreateCategoryRequestDto.java
+++ b/src/main/java/com/shcho/shBlog/category/dto/CreateCategoryRequestDto.java
@@ -1,0 +1,9 @@
+package com.shcho.shBlog.category.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateCategoryRequestDto(
+        @NotBlank String name,
+        String description
+) {
+}

--- a/src/main/java/com/shcho/shBlog/category/dto/CreateCategoryResponseDto.java
+++ b/src/main/java/com/shcho/shBlog/category/dto/CreateCategoryResponseDto.java
@@ -1,0 +1,19 @@
+package com.shcho.shBlog.category.dto;
+
+import com.shcho.shBlog.category.entity.Category;
+
+public record CreateCategoryResponseDto(
+        Long blogPageId,
+        Long categoryId,
+        String categoryName,
+        String categoryDescription
+) {
+    public static CreateCategoryResponseDto from(Category category) {
+        return new CreateCategoryResponseDto(
+                category.getBlogPage().getId(),
+                category.getId(),
+                category.getName(),
+                category.getDescription()
+        );
+    }
+}

--- a/src/main/java/com/shcho/shBlog/category/dto/UpdateCategoryRequestDto.java
+++ b/src/main/java/com/shcho/shBlog/category/dto/UpdateCategoryRequestDto.java
@@ -1,0 +1,9 @@
+package com.shcho.shBlog.category.dto;
+
+import jakarta.validation.Valid;
+
+public record UpdateCategoryRequestDto(
+        @Valid String name,
+        String description
+) {
+}

--- a/src/main/java/com/shcho/shBlog/category/entity/Category.java
+++ b/src/main/java/com/shcho/shBlog/category/entity/Category.java
@@ -1,0 +1,42 @@
+package com.shcho.shBlog.category.entity;
+
+import com.shcho.shBlog.blogpage.entity.BlogPage;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blog_page_id", nullable = false)
+    private BlogPage blogPage;
+
+    public static Category of(BlogPage blogPage, String name, String description) {
+        return Category.builder()
+                .blogPage(blogPage)
+                .name(name)
+                .description(description)
+                .build();
+    }
+
+    public void updateCategory(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/shcho/shBlog/category/repository/CategoryRepository.java
+++ b/src/main/java/com/shcho/shBlog/category/repository/CategoryRepository.java
@@ -1,0 +1,12 @@
+package com.shcho.shBlog.category.repository;
+
+import com.shcho.shBlog.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    boolean existsByBlogPage_IdAndName(Long blogPageId, String name);
+
+    List<Category> findAllByBlogPage_IdOrderByNameAsc(Long blogPageId);
+}

--- a/src/main/java/com/shcho/shBlog/category/service/CategoryService.java
+++ b/src/main/java/com/shcho/shBlog/category/service/CategoryService.java
@@ -3,6 +3,7 @@ package com.shcho.shBlog.category.service;
 import com.shcho.shBlog.blogpage.entity.BlogPage;
 import com.shcho.shBlog.blogpage.repository.BlogPageRepository;
 import com.shcho.shBlog.category.dto.CreateCategoryRequestDto;
+import com.shcho.shBlog.category.dto.UpdateCategoryRequestDto;
 import com.shcho.shBlog.category.entity.Category;
 import com.shcho.shBlog.category.repository.CategoryRepository;
 import com.shcho.shBlog.libs.exception.CustomException;
@@ -41,7 +42,7 @@ public class CategoryService {
     }
 
     @Transactional
-    public Category updateCategory(Long userId, Long categoryId, CreateCategoryRequestDto requestDto) {
+    public Category updateCategory(Long userId, Long categoryId, UpdateCategoryRequestDto requestDto) {
 
         BlogPage userBlogPage = getBlogPageByUserId(userId);
         Category category = findCategoryById(categoryId);

--- a/src/main/java/com/shcho/shBlog/category/service/CategoryService.java
+++ b/src/main/java/com/shcho/shBlog/category/service/CategoryService.java
@@ -1,0 +1,93 @@
+package com.shcho.shBlog.category.service;
+
+import com.shcho.shBlog.blogpage.entity.BlogPage;
+import com.shcho.shBlog.blogpage.repository.BlogPageRepository;
+import com.shcho.shBlog.category.dto.CreateCategoryRequestDto;
+import com.shcho.shBlog.category.entity.Category;
+import com.shcho.shBlog.category.repository.CategoryRepository;
+import com.shcho.shBlog.libs.exception.CustomException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.shcho.shBlog.libs.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+    private final BlogPageRepository blogPageRepository;
+
+    public Category createCategory(Long userId, CreateCategoryRequestDto requestDto) {
+
+        BlogPage blogPage = getBlogPageByUserId(userId);
+
+        validateDuplicateName(blogPage.getId(), requestDto.name());
+
+        return categoryRepository.save(
+                Category.of(blogPage, requestDto.name(), requestDto.description())
+        );
+    }
+
+    public List<Category> getAllCategoriesByBlogPageId(Long blogPageId) {
+
+        blogPageRepository.findById(blogPageId)
+                .orElseThrow(() -> new CustomException(BLOG_PAGE_NOT_FOUND));
+
+        return categoryRepository.findAllByBlogPage_IdOrderByNameAsc(blogPageId);
+    }
+
+    @Transactional
+    public Category updateCategory(Long userId, Long categoryId, CreateCategoryRequestDto requestDto) {
+
+        BlogPage userBlogPage = getBlogPageByUserId(userId);
+        Category category = findCategoryById(categoryId);
+
+        validateCategoryOwner(category, userBlogPage);
+
+        if (!category.getName().equals(requestDto.name())) {
+            validateDuplicateName(userBlogPage.getId(), requestDto.name());
+        }
+
+        category.updateCategory(requestDto.name(), requestDto.description());
+
+        return categoryRepository.save(category);
+    }
+
+
+    @Transactional
+    public void deleteCategoryByCategoryId(Long userId, Long categoryId) {
+
+        BlogPage userBlogPage = getBlogPageByUserId(userId);
+        Category category = findCategoryById(categoryId);
+
+        validateCategoryOwner(category, userBlogPage);
+
+        categoryRepository.delete(category);
+    }
+
+    private Category findCategoryById(Long categoryId) {
+        return categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new CustomException(CATEGORY_NOT_FOUND));
+    }
+
+    private BlogPage getBlogPageByUserId(Long userId) {
+        return blogPageRepository.getBlogPageByUser_UserId(userId)
+                .orElseThrow(() -> new CustomException(BLOG_PAGE_NOT_FOUND));
+    }
+
+    private void validateCategoryOwner(Category category, BlogPage userBlogPage) {
+        if (!category.getBlogPage().getId().equals(userBlogPage.getId())) {
+            throw new CustomException(FORBIDDEN_CATEGORY);
+        }
+    }
+
+    private void validateDuplicateName(Long blogPageId, String categoryName) {
+        if (categoryRepository.existsByBlogPage_IdAndName(blogPageId, categoryName)) {
+            throw new CustomException(DUPLICATED_CATEGORY_NAME);
+        }
+    }
+}

--- a/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
@@ -13,17 +13,20 @@ public enum ErrorCode {
     USER_NOT_FOUND(404, "USER_001", "유저를 찾을 수 없습니다."),
     ALREADY_DELETED_USER(404, "USER_002", "이미 삭제된 유저입니다."),
     BLOG_PAGE_NOT_FOUND(404, "BLOG_PAGE_001", "해당 블로그 페이지를 찾을 수 없습니다."),
+    CATEGORY_NOT_FOUND(404, "CATEGORY_002", "카테고리를 찾을 수 없습니다."),
 
     /* 401 UNAUTHORIZED */
     INVALID_USERNAME_OR_PASSWORD(401, "AUTH_001", "아이디 또는 비밀번호가 올바르지 않습니다."),
 
     /* 403 FORBIDDEN */
     NO_PERMISSION(403, "COMMON_403", "해당 작업을 할 권한이 없습니다."),
+    FORBIDDEN_CATEGORY(403, "CATEGORY_003", "해당 카테고리에 대한 권한이 없습니다."),
 
     /* 409 CONFLICT */
     DUPLICATED_USERNAME(409, "USER_003", "이미 사용중인 아이디 입니다."),
     DUPLICATED_EMAIL(409, "USER_004", "이미 사용중인 이메일 입니다."),
     DUPLICATED_NICKNAME(409, "USER_005", "이미 사용중인 닉네임 입니다."),
+    DUPLICATED_CATEGORY_NAME(409, "CATEGORY_001", "이미 사용 중인 카테고리명입니다." ),
 
     /* 500 INTERNAL_SERVER_ERROR */
     INTERNAL_SERVER_ERROR(500, "COMMON_500", "서버 오류가 발생했습니다."),

--- a/src/test/java/com/shcho/shBlog/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/shcho/shBlog/category/service/CategoryServiceTest.java
@@ -1,0 +1,387 @@
+package com.shcho.shBlog.category.service;
+
+import com.shcho.shBlog.blogpage.entity.BlogPage;
+import com.shcho.shBlog.blogpage.repository.BlogPageRepository;
+import com.shcho.shBlog.category.dto.CreateCategoryRequestDto;
+import com.shcho.shBlog.category.dto.UpdateCategoryRequestDto;
+import com.shcho.shBlog.category.entity.Category;
+import com.shcho.shBlog.category.repository.CategoryRepository;
+import com.shcho.shBlog.libs.exception.CustomException;
+import com.shcho.shBlog.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.shcho.shBlog.libs.exception.ErrorCode.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@DisplayName("Category Service Unit Test")
+class CategoryServiceTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private BlogPageRepository blogPageRepository;
+
+    @InjectMocks
+    private CategoryService categoryService;
+
+    public CategoryServiceTest() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("Category 생성 성공")
+    void createCategorySuccess() {
+        // given
+        Long userId = 1L;
+        Long blogPageId = 1L;
+
+        User user = buildUser(userId);
+
+        BlogPage blogPage = buildBlogPage(blogPageId, user);
+
+        CreateCategoryRequestDto requestDto =
+                new CreateCategoryRequestDto("newCategory", "newDescription");
+
+        when(blogPageRepository.getBlogPageByUser_UserId(userId))
+                .thenReturn(Optional.of(blogPage));
+        when(categoryRepository.existsByBlogPage_IdAndName(blogPageId, "newCategory"))
+                .thenReturn(false);
+        when(categoryRepository.save(any(Category.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+
+        // when
+        Category category = categoryService.createCategory(userId, requestDto);
+
+        // then
+        ArgumentCaptor<Category> categoryCaptor = ArgumentCaptor.forClass(Category.class);
+        verify(categoryRepository).save(categoryCaptor.capture());
+
+        // captor 객체 검증
+        assertAll(
+                () -> assertEquals(requestDto.name(), categoryCaptor.getValue().getName()),
+                () -> assertEquals(requestDto.description(), categoryCaptor.getValue().getDescription()),
+                () -> assertEquals(blogPageId, categoryCaptor.getValue().getBlogPage().getId())
+        );
+
+        // service return 객체 검증
+        assertAll(
+                () -> assertEquals(requestDto.name(), category.getName()),
+                () -> assertEquals(requestDto.description(), category.getDescription())
+        );
+    }
+
+    @Test
+    @DisplayName("Category 생성 실패 - 중복된 Category 명")
+    void createCategoryFailedDuplicatedCategoryName() {
+        // given
+        Long userId = 1L;
+        Long blogPageId = 1L;
+
+        User user = buildUser(userId);
+
+        BlogPage blogPage = buildBlogPage(blogPageId, user);
+
+        CreateCategoryRequestDto requestDto =
+                new CreateCategoryRequestDto("newCategory", "newDescription");
+
+        when(blogPageRepository.getBlogPageByUser_UserId(userId))
+                .thenReturn(Optional.of(blogPage));
+        when(categoryRepository.existsByBlogPage_IdAndName(blogPageId, "newCategory"))
+                .thenReturn(true);
+        when(categoryRepository.save(any(Category.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> categoryService.createCategory(userId, requestDto));
+
+        assertEquals(DUPLICATED_CATEGORY_NAME, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("Category 조회 성공")
+    void getAllCategoriesByBlogPageIdSuccess() {
+        // given
+        Long blogPageId = 1L;
+
+        BlogPage blogPage = buildBlogPage(blogPageId);
+
+        List<Category> categories = new ArrayList<>();
+
+        for (long i = 1L; i <= 3L; i++) {
+            categories.add(
+                    Category.builder()
+                            .id(i)
+                            .name("Category " + i)
+                            .description("No." + i + "category")
+                            .build()
+            );
+        }
+
+        when(blogPageRepository.findById(blogPageId))
+                .thenReturn(Optional.of(blogPage));
+        when(categoryRepository.findAllByBlogPage_IdOrderByNameAsc(blogPageId))
+                .thenReturn(categories);
+
+        // when
+        List<Category> allCategoriesByBlogPageId =
+                categoryService.getAllCategoriesByBlogPageId(blogPageId);
+
+        // then
+        assertEquals(3, allCategoriesByBlogPageId.size());
+        assertAll(
+                () -> assertEquals(categories.get(0), allCategoriesByBlogPageId.get(0)),
+                () -> assertEquals(categories.get(1), allCategoriesByBlogPageId.get(1))
+        );
+    }
+
+    @Test
+    @DisplayName("Category 수정 성공")
+    void updateCategorySuccess() {
+        // given
+        Long blogPageId = 1L;
+        Long userId = 1L;
+        Long categoryId = 1L;
+
+        User user = buildUser(userId);
+        BlogPage blogPage = buildBlogPage(blogPageId, user);
+
+        Category oldCategory = Category.builder()
+                .id(categoryId)
+                .name("oldCategory")
+                .description("oldDescription")
+                .blogPage(blogPage)
+                .build();
+
+        UpdateCategoryRequestDto requestDto =
+                new UpdateCategoryRequestDto("updateCategory", "updateDescription");
+
+        when(blogPageRepository.getBlogPageByUser_UserId(userId))
+                .thenReturn(Optional.of(blogPage));
+        when(categoryRepository.findById(categoryId))
+                .thenReturn(Optional.of(oldCategory));
+        when(categoryRepository.existsByBlogPage_IdAndName(blogPageId, requestDto.name()))
+                .thenReturn(false);
+        when(categoryRepository.save(any(Category.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        Category updatedCategory = categoryService.updateCategory(userId, categoryId, requestDto);
+
+        // then
+        ArgumentCaptor<Category> categoryCaptor = ArgumentCaptor.forClass(Category.class);
+        verify(categoryRepository).save(categoryCaptor.capture());
+        Category savedCategory = categoryCaptor.getValue();
+
+        assertAll(
+                () -> assertEquals(categoryId, savedCategory.getId()),
+                () -> assertEquals(requestDto.name(), savedCategory.getName()),
+                () -> assertEquals(requestDto.description(), savedCategory.getDescription()),
+                () -> assertEquals(blogPageId, savedCategory.getBlogPage().getId())
+        );
+
+        // service 반환값도 동일하게 검증
+        assertAll(
+                () -> assertEquals(categoryId, updatedCategory.getId()),
+                () -> assertEquals(requestDto.name(), updatedCategory.getName()),
+                () -> assertEquals(requestDto.description(), updatedCategory.getDescription())
+        );
+    }
+
+    @Test
+    @DisplayName("Category 수정 성공 - Description 수정")
+    void updateCategorySuccessChangeDescription() {
+        Long blogPageId = 1L;
+        Long userId = 1L;
+        Long categoryId = 1L;
+
+        User user = buildUser(userId);
+        BlogPage blogPage = buildBlogPage(blogPageId, user);
+
+        Category oldCategory = Category.builder()
+                .id(categoryId)
+                .name("oldCategory")
+                .description("oldDescription")
+                .blogPage(blogPage)
+                .build();
+
+        UpdateCategoryRequestDto requestDto =
+                new UpdateCategoryRequestDto("oldCategory", "updateDescription");
+
+        when(blogPageRepository.getBlogPageByUser_UserId(userId))
+                .thenReturn(Optional.of(blogPage));
+        when(categoryRepository.findById(categoryId))
+                .thenReturn(Optional.of(oldCategory));
+        when(categoryRepository.existsByBlogPage_IdAndName(blogPageId, requestDto.name()))
+                .thenReturn(false);
+        when(categoryRepository.save(any(Category.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        Category updatedCategory = categoryService.updateCategory(userId, categoryId, requestDto);
+
+        // then
+        ArgumentCaptor<Category> categoryCaptor = ArgumentCaptor.forClass(Category.class);
+        verify(categoryRepository).save(categoryCaptor.capture());
+        Category savedCategory = categoryCaptor.getValue();
+
+        assertAll(
+                () -> assertEquals(categoryId, savedCategory.getId()),
+                () -> assertEquals(requestDto.name(), savedCategory.getName()),
+                () -> assertEquals(requestDto.description(), savedCategory.getDescription()),
+                () -> assertEquals(blogPageId, savedCategory.getBlogPage().getId())
+        );
+
+        // service 반환값도 동일하게 검증
+        assertAll(
+                () -> assertEquals(categoryId, updatedCategory.getId()),
+                () -> assertEquals(requestDto.name(), updatedCategory.getName()),
+                () -> assertEquals(requestDto.description(), updatedCategory.getDescription())
+        );
+    }
+
+    @Test
+    @DisplayName("Category 수정 실패 - 권한 없음 (다른 유저의 카테고리)")
+    void updateCategoryFailedForbidden() {
+        Long blogPageId = 1L;
+        Long userId = 1L;
+        Long categoryId = 1L;
+
+        // 사용자 A의 BlogPage
+        User userA = buildUser(userId);
+        BlogPage blogPageA = buildBlogPage(blogPageId, userA);
+
+        // 카테고리는 사용자 B의 BlogPage에 속함
+        User userB = buildUser(2L);
+        BlogPage blogPageB = buildBlogPage(2L, userB);
+
+        Category category = buildCategory(categoryId, blogPageB);
+
+        UpdateCategoryRequestDto requestDto =
+                new UpdateCategoryRequestDto("updateCategory", "updateDescription");
+
+        when(blogPageRepository.getBlogPageByUser_UserId(userId))
+                .thenReturn(Optional.of(blogPageA));
+        when(categoryRepository.findById(categoryId))
+                .thenReturn(Optional.of(category));
+
+        CustomException exception = assertThrows(CustomException.class,
+                () -> categoryService.updateCategory(userId, categoryId, requestDto));
+
+        assertEquals(FORBIDDEN_CATEGORY, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("Category 삭제 실패 - 존재하지 않는 Category")
+    void deleteCategoryFailedNotFound() {
+        Long userId = 1L;
+        Long categoryId = 1L;
+
+        when(blogPageRepository.getBlogPageByUser_UserId(userId))
+                .thenReturn(Optional.of(buildBlogPage(1L)));
+
+        when(categoryRepository.findById(categoryId))
+                .thenReturn(Optional.empty());
+
+        CustomException exception = assertThrows(CustomException.class,
+                () -> categoryService.deleteCategoryByCategoryId(userId, categoryId));
+
+        assertEquals(CATEGORY_NOT_FOUND, exception.getErrorCode());
+    }
+
+
+    @Test
+    @DisplayName("Category 수정 실패 - 존재하는 카테고리 명")
+    void updateCategoryFailedDuplicatedCategoryName() {
+        // given
+        Long userId = 1L;
+        Long blogPageId = 1L;
+        Long categoryId = 1L;
+
+        User user = buildUser(userId);
+        BlogPage blogPage = buildBlogPage(blogPageId, user);
+        Category category = buildCategory(categoryId, blogPage);
+
+        UpdateCategoryRequestDto requestDto =
+                new UpdateCategoryRequestDto("updateCategory", "updateDescription");
+
+        when(blogPageRepository.getBlogPageByUser_UserId(userId))
+                .thenReturn(Optional.of(blogPage));
+        when(categoryRepository.findById(categoryId))
+                .thenReturn(Optional.of(category));
+        when(categoryRepository.existsByBlogPage_IdAndName(blogPageId, requestDto.name()))
+                .thenReturn(true);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> categoryService.updateCategory(userId, categoryId, requestDto));
+
+        assertEquals(DUPLICATED_CATEGORY_NAME, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("카테고리 삭제 성공")
+    void deleteCategorySuccess() {
+        // given
+        Long blogPageId = 1L;
+        Long userId = 1L;
+        Long categoryId = 1L;
+
+        User user = buildUser(userId);
+        BlogPage blogPage = buildBlogPage(blogPageId, user);
+        Category category = buildCategory(categoryId, blogPage);
+
+        when(blogPageRepository.getBlogPageByUser_UserId(userId))
+                .thenReturn(Optional.of(blogPage));
+        when(categoryRepository.findById(categoryId))
+                .thenReturn(Optional.of(category));
+
+        // when
+        categoryService.deleteCategoryByCategoryId(userId, categoryId);
+
+        // then
+        verify(categoryRepository, times(1)).delete(category);
+    }
+
+    private User buildUser(Long userId) {
+        return User.builder()
+                .userId(userId)
+                .build();
+    }
+
+
+    private BlogPage buildBlogPage(Long blogPageId) {
+        return BlogPage.builder()
+                .id(blogPageId)
+                .build();
+    }
+
+    private BlogPage buildBlogPage(Long blogPageId, User user) {
+        return BlogPage.builder()
+                .id(blogPageId)
+                .user(user)
+                .build();
+    }
+
+    private Category buildCategory(Long categoryId, BlogPage blogPage) {
+        return Category.builder()
+                .id(categoryId)
+                .name("Category " + categoryId)
+                .description("No." + categoryId + "category")
+                .blogPage(blogPage)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] Category 도메인 구현 및 서비스/테스트 추가

## ✅ 작업 내용
- 블로그 게시글 기능 개발을 위한 Category 도메인을 구현
- BlogPage 기준으로 카테고리를 관리하도록 설계했으며, 생성/조회/수정/삭제 기능을 제공
- 카테고리 이름 중복 방지 및 소유자 권한 검증 로직을 포함
- Category Service 단위 테스트를 작성하여 주요 성공/실패 시나리오를 검증

## 🧪 테스트
- Category Service 단위 테스트 작성
  - 생성/조회/수정/삭제 성공 케이스
  - 중복 이름 예외
  - 권한 없는 사용자 접근 예외
  - 존재하지 않는 Category 접근 예외

## 🔧 변경사항
- Category 엔티티 및 Repository 추가
- CategoryService / CategoryController 구현
- 중복 이름 검증 및 권한 검증 로직 추가
- Category Service 단위 테스트 작성

## 📌 관련 이슈
- close #21 