### PR TITLE
[Feat] Post 엔티티 및 Repository 구현

### DIFF
--- a/src/main/java/com/shcho/shBlog/post/entity/Post.java
+++ b/src/main/java/com/shcho/shBlog/post/entity/Post.java
@@ -1,0 +1,68 @@
+package com.shcho.shBlog.post.entity;
+
+import com.shcho.shBlog.blogpage.entity.BlogPage;
+import com.shcho.shBlog.category.entity.Category;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private boolean published;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blog_page_id", nullable = false)
+    private BlogPage blogPage;
+
+    // 초안 생성
+    public static Post createDraft(
+            BlogPage blogPage,
+            Category category,
+            String title,
+            String content
+    ) {
+        return Post.builder()
+                .title(title)
+                .content(content)
+                .category(category)
+                .published(false)
+                .blogPage(blogPage)
+                .build();
+    }
+
+    public void publish() {
+        this.published = true;
+    }
+
+    public void unpublish() {
+        this.published = false;
+    }
+
+    public void update(String title, String content, Category category) {
+        this.title = title;
+        this.content = content;
+        this.category = category;
+    }
+}

--- a/src/main/java/com/shcho/shBlog/post/repository/PostRepository.java
+++ b/src/main/java/com/shcho/shBlog/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.shcho.shBlog.post.repository;
+
+import com.shcho.shBlog.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] Post 엔티티 및 Repository 구현

## ✅ 작업 내용
- Post 엔티티 구현
  - title, content, published 필드 정의
  - Category, BlogPage와의 연관관계 설정
- 도메인 메서드 추가
  - 초안 생성 (`createDraft`)
  - 게시 / 게시 취소 (`publish`, `unpublish`)
  - 게시글 수정 (`update`)
- PostRepository(JPA) 생성

## 🔧 변경사항
- Post.java
- PostRepository.java

## 📌 관련 이슈
- close #24 